### PR TITLE
Add configurable JSON path and shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,25 @@
       "command": "dart-bean-generator.generate",
       "title": "Generate Dart Bean Class"
       }
-    ]
+    ],
+    "keybindings": [
+      {
+        "command": "dart-bean-generator.generate",
+        "key": "alt+j",
+        "when": "editorTextFocus"
+      }
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Dart Bean Generator",
+      "properties": {
+        "dart-bean-generator.jsonDirPath": {
+          "type": "string",
+          "default": "lib/generated/json",
+          "description": "Path for generated JSON files relative to the workspace root"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run package",


### PR DESCRIPTION
## Summary
- add `dart-bean-generator.jsonDirPath` setting
- register Alt+J keybinding
- use configured jsonDirPath when generating files

## Testing
- `npm run compile`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e9bb2b4ac8324bf9dee1a40d2214d